### PR TITLE
KamaiZen one plugin with LSP and Treesitter parser for kamailio configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-KamaiZen
+#KamaiZen
 *.log
 
 # Binaries for programs and plugins

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,6 @@
+column_width = 160
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferSingle"
+call_parentheses = "None"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ with [lazy.nvim](https://github.com/folke/lazy.nvim):
 
 ### Neovim
 
-- [x] [kamaizen.nvim](https://github.com/IbrahimShahzad/kamaizen.nvim)
+- [x] [KamaiZen](https://github.com/IbrahimShahzad/KamaiZen)
 
 ### Vscode
 

--- a/README.md
+++ b/README.md
@@ -42,43 +42,21 @@ For syntax highlighting, use [tree-sitter-kamailio-cfg](https://github.com/Ibrah
 
 ## Installation
 
-### From source
-
-```bash
-git clone https://github.com/IbrahimShahzad/KamaiZen.git 
-cd KamaiZen
-go build
-cp KamaiZen /usr/local/bin
-```
-
-### To use with Neovim
-
-update your `init.lua` with the following
-
+with [lazy.nvim](https://github.com/folke/lazy.nvim):
 ```lua
-local client = vim.lsp.start_client {
-  cmd = { '/usr/local/bin/KamaiZen' }, -- Path to KamaiZen executable
-  name = 'KamaiZen',
-  settings = {
-    kamaizen = {
-      logLevel = 1,
-      kamailioSourcePath = '/path/to/kamailio-source', -- Path to kamailio source
-      enableDeprecatedCommentHint = false, -- to enable hints for '#' comments
-    },
-  },
-}
-
-if not client then
-  vim.notify('Failed to start LSP client', vim.log.levels.ERROR)
-  return
-end
-
-vim.api.nvim_create_autocmd('FileType', {
-  pattern = 'kamailio',
-  callback = function()
-    vim.lsp.buf_attach_client(0, client)
-  end,
-})
+    {
+      'batoaqaa/KamaiZen',
+      dependencies = { 'batoaqaa/KamaiZen', build = 'go build' },
+      opts = {
+        settings = {
+          kamaizen = {
+            enableDeprecatedCommentHint = false, -- to enable hints for '#' comments
+            KamailioSourcePath = vim.fn.getcwd(),
+            loglevel = 3,
+          },
+        },
+      },
+    }
 ```
 
 ## Integration

--- a/after/queries/kamailio/highlights.scm
+++ b/after/queries/kamailio/highlights.scm
@@ -1,0 +1,128 @@
+(file_starter) @module
+(comment) @comment
+(multiline_comment) @comment
+
+(preproc_def
+  (preproc_arg) @variable.parameter)
+(preproc_subst
+  (preproc_arg) @string.regexp) @keyword.directive
+(preproc_substdef
+  (preproc_arg) @string.regexp) @keyword.directive.define
+(preproc_substdefs
+  (preproc_arg) @string.regexp) @keyword.directive.define
+(preproc_trydef
+  (preproc_arg) @variable.parameter)
+(preproc_ifdef) @keyword.directive
+(preproc_ifndef) @keyword.directive
+(preproc_trydef) @keyword.directive.define
+(preproc_def) @keyword.directive.define
+(include_file
+  file_name: (string) @string.special.path) @keyword.directive
+(import_file
+  file_name: (string) @string.special.path) @keyword.directive
+(route_call) @function
+
+(regex_pattern) @string.regexp
+(regex_replacement) @string.regexp
+(regex_flags) @string.regexp
+(pseudo_variable
+   "$" @keyword.operator
+   var: (pseudo_content) @attribute.builtin)
+(var_
+  name: (identifier) @variable.parameter)
+(avp_var
+  name: (pvar_argument) @variable.parameter)
+ (pvar_expression
+   "$" @keyword.operator
+   var: (pseudo_content) @attribute.builtin)
+(xavp_values
+  name: (identifier) @variable.parameter
+  index: (identifier) @variable.builtin
+  field: (identifier) @property)
+(transformation) @variable.parameter
+(htable
+  htable: (identifier) @variable.parameter
+  "=>" @punctuation.special)
+
+(modparam
+  module_name: (string) @string.special.path) @function.builtin
+(modparamx
+  module_name: (string) @string.special.path) @function.builtin
+(loadmodule
+  module_name: (string) @string.special.path) @keyword.import
+(loadmodulex
+  module_name: (string) @string.special.path) @keyword.import
+
+(loadpath
+  path: (string) @string.special.path) @keyword.import
+
+(top_level_assignment_expression
+  key: (identifier) @variable.member
+  value: (expression) @variable.parameter)
+
+(string) @string
+(call_expression
+  function: (expression) @function.call
+  arguments: (argument_list
+    "(" @punctuation.bracket
+    ")" @punctuation.bracket) @variable.parameter)
+
+(number_literal) @number
+
+(predef_route) @keyword
+(route_name) @variable.parameter
+
+(true) @keyword
+(false) @keyword
+(null) @keyword
+
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"{" @punctuation.bracket
+"}" @punctuation.bracket
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+
+"=" @operator
+"==" @operator
+">" @operator
+"<" @operator
+">=" @operator
+"<=" @operator
+"!=" @operator
+"=~" @operator
+"+=" @operator
+"!" @operator
+"&&" @operator
+"&" @operator
+"||" @operator
+"|" @operator
+"^" @operator
+"<<" @operator
+">>" @operator
+"+" @operator
+"-" @operator
+
+"." @punctuation.delimiter
+"," @punctuation.delimiter
+";" @punctuation.delimiter
+":" @punctuation.delimiter
+"::" @character.special
+
+"or" @keyword.operator
+"not" @keyword.operator
+"and" @keyword.operator
+
+[ "break"
+  "continue"
+  "return"
+  "switch"
+  "drop"
+  "exit"] @keyword.return
+
+[ "while" ] @keyword.repeat
+[  "if"
+   "else"
+   "default"
+   "case" ] @keyword.conditional
+

--- a/lua/KamaiZen/config.lua
+++ b/lua/KamaiZen/config.lua
@@ -4,40 +4,40 @@ local capabilities = vim.lsp.protocol.make_client_capabilities()
 capabilities.textDocument.foldingRange = { dynamicRegistration = false, lineFoldingOnly = true }
 
 local server = {
-	name = "KamaiZen",
-	cmd = { vim.fn.stdpath("data") .. "/lazy/KamaiZen/KamaiZen" },
+  name = 'KamaiZen',
+  cmd = { vim.fn.stdpath 'data' .. '/lazy/KamaiZen/KamaiZen' },
 
-	cmd_cwd = vim.fn.getcwd(),
-	filetypes = { "cfg", "inc", "kamailio" },
-	root_dir = vim.fn.getcwd(),
-	capabilities = capabilities,
-	autostart = true,
-	settings = {
-		kamaizen = {
-			enableDeprecatedCommentHint = false, -- to enable hints for '#' comments
-			KamailioSourcePath = vim.fn.getcwd(),
-			loglevel = 3,
-		},
-	},
-	on_init = function(client, results)
-		if results.offsetEncoding then
-			client.offset_encoding = results.offsetEncoding
-		end
+  cmd_cwd = vim.fn.getcwd(),
+  filetypes = { 'cfg', 'inc', 'kamailio' },
+  root_dir = vim.fn.getcwd(),
+  capabilities = capabilities,
+  autostart = true,
+  settings = {
+    kamaizen = {
+      enableDeprecatedCommentHint = false, -- to enable hints for '#' comments
+      KamailioSourcePath = vim.fn.getcwd(),
+      loglevel = 3,
+    },
+  },
+  on_init = function(client, results)
+    if results.offsetEncoding then
+      client.offset_encoding = results.offsetEncoding
+    end
 
-		-- if client.config.settings then
-		--   client.notify('workspace/didChangeConfiguration', {
-		--     settings = client.config.settings,
-		--   })
-		-- end
-	end,
-	--on_exit = function(code, signal, client_id)
-	on_exit = function(_, _, client_id)
-		vim.schedule(function()
-			vim.api.nvim_del_autocmd(state.autocmd[client_id])
-		end)
-	end,
+    -- if client.config.settings then
+    --   client.notify('workspace/didChangeConfiguration', {
+    --     settings = client.config.settings,
+    --   })
+    -- end
+  end,
+  --on_exit = function(code, signal, client_id)
+  on_exit = function(_, _, client_id)
+    vim.schedule(function()
+      vim.api.nvim_del_autocmd(state.autocmd[client_id])
+    end)
+  end,
 }
 
 return {
-	server_opts = server,
+  server_opts = server,
 }

--- a/lua/KamaiZen/config.lua
+++ b/lua/KamaiZen/config.lua
@@ -1,0 +1,43 @@
+local state = { autocmd = {} }
+
+local capabilities = vim.lsp.protocol.make_client_capabilities()
+capabilities.textDocument.foldingRange = { dynamicRegistration = false, lineFoldingOnly = true }
+
+local server = {
+	name = "KamaiZen",
+	cmd = { vim.fn.stdpath("data") .. "/lazy/KamaiZen/KamaiZen" },
+
+	cmd_cwd = vim.fn.getcwd(),
+	filetypes = { "cfg", "inc", "kamailio" },
+	root_dir = vim.fn.getcwd(),
+	capabilities = capabilities,
+	autostart = true,
+	settings = {
+		kamaizen = {
+			enableDeprecatedCommentHint = false, -- to enable hints for '#' comments
+			KamailioSourcePath = vim.fn.getcwd(),
+			loglevel = 3,
+		},
+	},
+	on_init = function(client, results)
+		if results.offsetEncoding then
+			client.offset_encoding = results.offsetEncoding
+		end
+
+		-- if client.config.settings then
+		--   client.notify('workspace/didChangeConfiguration', {
+		--     settings = client.config.settings,
+		--   })
+		-- end
+	end,
+	--on_exit = function(code, signal, client_id)
+	on_exit = function(_, _, client_id)
+		vim.schedule(function()
+			vim.api.nvim_del_autocmd(state.autocmd[client_id])
+		end)
+	end,
+}
+
+return {
+	server_opts = server,
+}

--- a/lua/KamaiZen/init.lua
+++ b/lua/KamaiZen/init.lua
@@ -1,0 +1,67 @@
+local config = require("KamaiZen.config")
+local M = {}
+
+M.setup = function(opts)
+	-- opts = opts or {}
+	opts = vim.tbl_deep_extend("force", config.server_opts or {}, opts)
+
+	vim.filetype.add({
+		extension = {
+			cfg = "kamailio",
+		},
+		filename = {
+			["kamctlrc"] = "kamailio",
+		},
+		pattern = {
+			[".*"] = {
+				--set files that start with '#!KAMAILIO' as kamailio file type
+				--function(path, bufnr)
+				function(_, bufnr)
+					local content = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1] or ""
+					if vim.regex([[^#!.*KAMAILIO]]):match_str(content) ~= nil then
+						return "kamailio"
+					end
+				end,
+			},
+		},
+	})
+
+	vim.api.nvim_create_autocmd("FileType", {
+		pattern = "kamailio",
+		--callback = function(args)
+		callback = function()
+			----------------------------------------
+			local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
+			local parsers = require("nvim-treesitter.parsers")
+
+			-- if not parser_config["kamailio"] then
+			if not parsers.has_parser("kamailio") then
+				parser_config["kamailio"] = {
+					install_info = {
+						-- url = 'https://github.com/IbrahimShahzad/tree-sitter-kamailio-cfg',
+						url = "https://github.com/batoaqaa/tree-sitter-kamailio", --'/home/batoaqaa/tree-sitter-kamailio', --
+						files = { "src/parser.c" }, -- note that some parsers also require src/scanner.c or src/scanner.cc
+						-- optional entries:
+						-- branch = 'v0.1.2', -- default branch in case of git repo if different from master
+						branch = "main", -- default branch in case of git repo if different from master
+						generate_requires_npm = false, -- if stand-alone parser without npm dependencies
+						requires_generate_from_grammar = false, -- if folder contains pre-generated src/parser.c
+					},
+					filetype = "kamailio", -- if filetype does not match the parser name
+				}
+
+				vim.schedule_wrap(function()
+					vim.cmd("TSInstall kamailio")
+				end)()
+			end
+			----------------------------------------
+			local id = vim.lsp.start(opts)
+			if not id then
+				vim.notify("Failed to start LSP client", vim.log.levels.ERROR)
+				return
+			end
+		end,
+	})
+end
+
+return M

--- a/lua/KamaiZen/init.lua
+++ b/lua/KamaiZen/init.lua
@@ -1,67 +1,67 @@
-local config = require("KamaiZen.config")
+local config = require 'KamaiZen.config'
 local M = {}
 
 M.setup = function(opts)
-	-- opts = opts or {}
-	opts = vim.tbl_deep_extend("force", config.server_opts or {}, opts)
+  -- opts = opts or {}
+  opts = vim.tbl_deep_extend('force', config.server_opts or {}, opts)
 
-	vim.filetype.add({
-		extension = {
-			cfg = "kamailio",
-		},
-		filename = {
-			["kamctlrc"] = "kamailio",
-		},
-		pattern = {
-			[".*"] = {
-				--set files that start with '#!KAMAILIO' as kamailio file type
-				--function(path, bufnr)
-				function(_, bufnr)
-					local content = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1] or ""
-					if vim.regex([[^#!.*KAMAILIO]]):match_str(content) ~= nil then
-						return "kamailio"
-					end
-				end,
-			},
-		},
-	})
+  vim.filetype.add {
+    extension = {
+      cfg = 'kamailio',
+    },
+    filename = {
+      ['kamctlrc'] = 'kamailio',
+    },
+    pattern = {
+      ['.*'] = {
+        --set files that start with '#!KAMAILIO' as kamailio file type
+        --function(path, bufnr)
+        function(_, bufnr)
+          local content = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1] or ''
+          if vim.regex([[^#!.*KAMAILIO]]):match_str(content) ~= nil then
+            return 'kamailio'
+          end
+        end,
+      },
+    },
+  }
 
-	vim.api.nvim_create_autocmd("FileType", {
-		pattern = "kamailio",
-		--callback = function(args)
-		callback = function()
-			----------------------------------------
-			local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
-			local parsers = require("nvim-treesitter.parsers")
+  vim.api.nvim_create_autocmd('FileType', {
+    pattern = 'kamailio',
+    --callback = function(args)
+    callback = function()
+      ----------------------------------------
+      local parser_config = require('nvim-treesitter.parsers').get_parser_configs()
+      local parsers = require 'nvim-treesitter.parsers'
 
-			-- if not parser_config["kamailio"] then
-			if not parsers.has_parser("kamailio") then
-				parser_config["kamailio"] = {
-					install_info = {
-						-- url = 'https://github.com/IbrahimShahzad/tree-sitter-kamailio-cfg',
-						url = "https://github.com/batoaqaa/tree-sitter-kamailio", --'/home/batoaqaa/tree-sitter-kamailio', --
-						files = { "src/parser.c" }, -- note that some parsers also require src/scanner.c or src/scanner.cc
-						-- optional entries:
-						-- branch = 'v0.1.2', -- default branch in case of git repo if different from master
-						branch = "main", -- default branch in case of git repo if different from master
-						generate_requires_npm = false, -- if stand-alone parser without npm dependencies
-						requires_generate_from_grammar = false, -- if folder contains pre-generated src/parser.c
-					},
-					filetype = "kamailio", -- if filetype does not match the parser name
-				}
+      -- if not parser_config["kamailio"] then
+      if not parsers.has_parser 'kamailio' then
+        parser_config['kamailio'] = {
+          install_info = {
+            -- url = 'https://github.com/IbrahimShahzad/tree-sitter-kamailio-cfg',
+            url = 'https://github.com/batoaqaa/tree-sitter-kamailio', --'/home/batoaqaa/tree-sitter-kamailio', --
+            files = { 'src/parser.c' }, -- note that some parsers also require src/scanner.c or src/scanner.cc
+            -- optional entries:
+            -- branch = 'v0.1.2', -- default branch in case of git repo if different from master
+            branch = 'main', -- default branch in case of git repo if different from master
+            generate_requires_npm = false, -- if stand-alone parser without npm dependencies
+            requires_generate_from_grammar = false, -- if folder contains pre-generated src/parser.c
+          },
+          filetype = 'kamailio', -- if filetype does not match the parser name
+        }
 
-				vim.schedule_wrap(function()
-					vim.cmd("TSInstall kamailio")
-				end)()
-			end
-			----------------------------------------
-			local id = vim.lsp.start(opts)
-			if not id then
-				vim.notify("Failed to start LSP client", vim.log.levels.ERROR)
-				return
-			end
-		end,
-	})
+        vim.schedule_wrap(function()
+          vim.cmd 'TSInstall kamailio'
+        end)()
+      end
+      ----------------------------------------
+      local id = vim.lsp.start(opts)
+      if not id then
+        vim.notify('Failed to start LSP client', vim.log.levels.ERROR)
+        return
+      end
+    end,
+  })
 end
 
 return M


### PR DESCRIPTION
Update to have one plugin combine LSP and Treesitter parser installation and configurations for kamailio files.

If choose to have one plugin (KamaiZen) for both LSP and Treesitter parser setting, then there is no need for kamaizen.nvim.